### PR TITLE
Choices are always `true` when using `copyTemplateToDestination`

### DIFF
--- a/src/BaseTemplateGenerator.ts
+++ b/src/BaseTemplateGenerator.ts
@@ -30,7 +30,10 @@ class TemplateArgument {
 function toTemplateArguments(obj: object): object {
   obj = _.cloneDeep(obj);
   for (const propertyName in obj) {
-    obj[propertyName] = new TemplateArgument(obj[propertyName]);
+    // only replace string values
+    if (typeof obj[propertyName] === 'string') {
+      obj[propertyName] = new TemplateArgument(obj[propertyName]);
+    }
   }
   return obj;
 }


### PR DESCRIPTION
Fixes #89